### PR TITLE
restart auto-dismiss timer when promise toast settles

### DIFF
--- a/packages/toastiva/src/hooks/use-toast-dismiss.ts
+++ b/packages/toastiva/src/hooks/use-toast-dismiss.ts
@@ -100,7 +100,18 @@ function useToastDismiss(params: IUseToastDismissParams) {
   ]);
 
   useEffect(() => {
+    remainingRef.current = null;
+  }, [displayDuration, toast.isLoading]);
+
+  useEffect(() => {
     if (paused) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+    if (toast.isLoading) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
         timerRef.current = null;
@@ -143,6 +154,7 @@ function useToastDismiss(params: IUseToastDismissParams) {
     showBody,
     shouldAutoExpand,
     toast,
+    toast.isLoading,
   ]);
 
   return { handleDismiss, isDismissing };


### PR DESCRIPTION
Promise toasts stayed on screen too long after success/error — they weren’t auto-closing on the expected duration because the loading timer was still being used after settle

Fixed: the auto-close timer now starts fresh once loading finishes, so the toast closes after the normal duration